### PR TITLE
Install CLIP from original repository

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ rapidfuzz
 pillow
 opencv-python
 timm>=0.5.0
-http://ofasys.oss-cn-zhangjiakou.aliyuncs.com/dependency/clip-1.0-py3-none-any.whl
+git+https://github.com/openai/clip.git
 diffusers
 matplotlib
 


### PR DESCRIPTION
The current wheel file did not work in my case --I had to install it from OpenAI's repo instead.